### PR TITLE
Improve caching of samples, guild configs and blacklisted users

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "fs-extra": "^10.0.0",
         "libsodium-wrappers": "^0.7.9",
         "mime": "^2.5.2",
-        "mongodb": "^4.0.1",
+        "mongodb": "^4.1.0",
         "nanoid": "^3.1.23",
         "node-fetch": "^2.6.1",
         "prism-media": "^1.3.1",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "fs-extra": "^10.0.0",
     "libsodium-wrappers": "^0.7.9",
     "mime": "^2.5.2",
-    "mongodb": "^4.0.1",
+    "mongodb": "^4.1.0",
     "nanoid": "^3.1.23",
     "node-fetch": "^2.6.1",
     "prism-media": "^1.3.1",

--- a/src/commands/owner/owner_blacklist.ts
+++ b/src/commands/owner/owner_blacklist.ts
@@ -1,7 +1,7 @@
 import { Command } from "../../modules/commands/Command";
 import { CommandGroup } from "../../modules/commands/CommandGroup";
 import { createStringOption } from "../../modules/commands/options/createOption";
-import { collectionBlacklistUser } from "../../modules/database/models";
+import * as models from "../../modules/database/models";
 import { EmbedType, isOwner, replyEmbedEphemeral } from "../../util/util";
 
 const blacklist_add_cmd = new Command({
@@ -17,7 +17,7 @@ const blacklist_add_cmd = new Command({
 
         const userId = interaction.options.getString("user-id", true).trim();
 
-        await collectionBlacklistUser().updateOne(
+        await models.blacklist_user.updateOne(
             { userId: userId },
             { $set: { userId: userId } },
             { upsert: true },
@@ -40,7 +40,7 @@ const blacklist_remove_cmd = new Command({
 
         const userId = interaction.options.getString("user-id", true).trim();
 
-        await collectionBlacklistUser().deleteOne(
+        await models.blacklist_user.deleteOne(
             { userId: userId },
         );
 

--- a/src/commands/owner/owner_delete.ts
+++ b/src/commands/owner/owner_delete.ts
@@ -4,7 +4,7 @@ import { createStringOption } from "../../modules/commands/options/createOption"
 import { EmbedType, isOwner, replyEmbed, replyEmbedEphemeral } from "../../util/util";
 
 import { CustomSample } from "../../core/soundboard/sample/CustomSample";
-import { PredefinedSample } from "../../core/soundboard/sample/PredefinedSample";
+import { StandardSample } from "../../core/soundboard/sample/StandardSample";
 
 const delete_extern_cmd = new Command({
     name: "extern",
@@ -46,12 +46,12 @@ const delete_standard_cmd = new Command({
             return replyEmbedEphemeral("You're not a bot developer, you can't remove standard samples.", EmbedType.Error);
         }
 
-        const sample = await PredefinedSample.findByName(name);
+        const sample = await StandardSample.findByName(name);
         if (!sample) {
             return replyEmbedEphemeral(`Couldn't find sample with name or id ${name}`, EmbedType.Error);
         }
 
-        await PredefinedSample.remove(sample);
+        await StandardSample.remove(sample);
 
         return replyEmbed(`Removed ${sample.name} from standard soundboard!`, EmbedType.Success);
     },

--- a/src/commands/owner/owner_import.ts
+++ b/src/commands/owner/owner_import.ts
@@ -1,7 +1,7 @@
 import { createStringOption } from "../../modules/commands/options/createOption";
 import { EmbedType, isOwner, replyEmbedEphemeral } from "../../util/util";
 import { CustomSample } from "../../core/soundboard/sample/CustomSample";
-import { PredefinedSample } from "../../core/soundboard/sample/PredefinedSample";
+import { StandardSample } from "../../core/soundboard/sample/StandardSample";
 import { Command } from "../../modules/commands/Command";
 
 export default new Command({
@@ -26,11 +26,11 @@ export default new Command({
             return replyEmbedEphemeral("This sample is marked as not importable.", EmbedType.Error);
         }
 
-        if (await PredefinedSample.findByName(sample.name)) {
+        if (await StandardSample.findByName(sample.name)) {
             return replyEmbedEphemeral("You already have a sample with this name in your soundboard.", EmbedType.Error);
         }
 
-        const new_sample = await PredefinedSample.import(sample);
+        const new_sample = await StandardSample.import(sample);
 
         return new_sample.toEmbed({ description: `Successfully imported sample "${new_sample.name}."`, type: EmbedType.Success });
     },

--- a/src/commands/soundboard/info.ts
+++ b/src/commands/soundboard/info.ts
@@ -9,7 +9,7 @@ import { TopCommand } from "../../modules/commands/TopCommand";
 
 import SampleID from "../../core/soundboard/SampleID";
 import { CustomSample } from "../../core/soundboard/sample/CustomSample";
-import { PredefinedSample } from "../../core/soundboard/sample/PredefinedSample";
+import { StandardSample } from "../../core/soundboard/sample/StandardSample";
 import GuildConfigManager from "../../core/GuildConfigManager";
 
 async function findSampleByScope(
@@ -17,11 +17,11 @@ async function findSampleByScope(
     userId: Discord.Snowflake,
     name: string,
     scope: "user" | "server" | null,
-): Promise<CustomSample | PredefinedSample | undefined> {
-    let sample: CustomSample | PredefinedSample | undefined;
+): Promise<CustomSample | StandardSample | undefined> {
+    let sample: CustomSample | StandardSample | undefined;
     if (!scope) {
         sample = await CustomSample.findByName(guildId, userId, name) ||
-                 await PredefinedSample.findByName(name);
+                 await StandardSample.findByName(name);
     } else if (scope === "user") {
         sample = await CustomSample.findSampleUser(userId, name);
     } else if (guildId) {

--- a/src/commands/soundboard/play.ts
+++ b/src/commands/soundboard/play.ts
@@ -8,14 +8,14 @@ import SampleID from "../../core/soundboard/SampleID";
 import AudioManager, { JoinFailureTypes } from "../../core/audio/AudioManager";
 import Logger from "../../log";
 import { CmdInstallerArgs } from "../../util/types";
-import { PredefinedSample } from "../../core/soundboard/sample/PredefinedSample";
+import { StandardSample } from "../../core/soundboard/sample/StandardSample";
 import { EmbedType, logErr, replyEmbedEphemeral } from "../../util/util";
 import { BUTTON_TYPES } from "../../const";
 
 const log = Logger.child({ label: "Command => play" });
 
 export function install({ stats_collector }: CmdInstallerArgs): void {
-    async function play(interaction: Discord.CommandInteraction | Discord.ButtonInteraction, sample: CustomSample | PredefinedSample) {
+    async function play(interaction: Discord.CommandInteraction | Discord.ButtonInteraction, sample: CustomSample | StandardSample) {
         try {
             // shouldn't true, but Typescript wants it
             if (!interaction.inGuild()) return;
@@ -63,7 +63,7 @@ export function install({ stats_collector }: CmdInstallerArgs): void {
 
         const name = decoded.n as string;
 
-        const sample = await PredefinedSample.findByName(name);
+        const sample = await StandardSample.findByName(name);
         if (!sample) return;
 
         return await play(interaction, sample);
@@ -83,7 +83,7 @@ export function install({ stats_collector }: CmdInstallerArgs): void {
             const name = interaction.options.getString("sample", true).trim();
 
             let sample = await CustomSample.findByName(interaction.guildId, interaction.user.id, name) ||
-                         await PredefinedSample.findByName(name);
+                         await StandardSample.findByName(name);
 
             if (!sample && SampleID.isId(name)) {
                 sample = await CustomSample.findById(name);

--- a/src/core/Core.ts
+++ b/src/core/Core.ts
@@ -12,7 +12,7 @@ import { TOP_GG_TOKEN } from "../config";
 import { EmbedType, guessModRole, logErr, replyEmbedEphemeral } from "../util/util";
 import AudioManager from "./audio/AudioManager";
 import GuildConfigManager from "./GuildConfigManager";
-import { collectionBlacklistUser } from "../modules/database/models";
+import * as models from "../modules/database/models";
 import { BUTTON_TYPES } from "../const";
 
 const log = Logger.child({ label: "Core" });
@@ -155,7 +155,7 @@ export default class Core {
 
     attachListeners(): void {
         this.client.on("interactionCreate", async interaction => {
-            if (await collectionBlacklistUser().findOne({ userId: interaction.user.id })) {
+            if (await models.blacklist_user.findOne({ userId: interaction.user.id })) {
                 if (!interaction.isCommand() && !interaction.isButton()) return;
 
                 return await interaction.reply(replyEmbedEphemeral("You're blacklisted from using this bot anywhere.", EmbedType.Error));

--- a/src/core/GuildConfigManager.ts
+++ b/src/core/GuildConfigManager.ts
@@ -1,6 +1,6 @@
 import Discord, { Awaited } from "discord.js";
 import { fetchMember, guessModRole } from "../util/util";
-import { collectionConfig } from "../modules/database/models";
+import * as models from "../modules/database/models";
 import { ConfigSchema } from "../modules/database/schemas/ConfigSchema";
 
 type OnAdminRoleChangeFunc = (guildId: Discord.Snowflake, roleId: Discord.Snowflake) => Awaited<void>;
@@ -9,7 +9,7 @@ class GuildConfigManager {
     private on_admin_role_change_handlers: OnAdminRoleChangeFunc[] = [];
 
     public async setConfig(guildId: Discord.Snowflake, config: ConfigSchema): Promise<void> {
-        await collectionConfig().replaceOne({ guildId }, config, { upsert: true });
+        await models.config.replaceOne({ guildId }, config, { upsert: true });
     }
 
     /**
@@ -17,7 +17,7 @@ class GuildConfigManager {
      */
     public async findOrGenConfig(guild: Discord.Guild): Promise<ConfigSchema> {
         // eslint-disable-next-line prefer-const
-        let { guildId, adminRoleId } = await collectionConfig().findOne({ guildId: guild.id }) || { guildId: guild.id };
+        let { guildId, adminRoleId } = await models.config.findOne({ guildId: guild.id }) || { guildId: guild.id };
         let data_changed = false;
 
         // if old admin role has been deleted, default back to the guessed role

--- a/src/core/StatsCollectorManager.ts
+++ b/src/core/StatsCollectorManager.ts
@@ -8,7 +8,7 @@ import database from "../modules/database";
 import { StatsSchema } from "../modules/database/schemas/StatsSchema";
 import Logger from "../log";
 import { CustomSample } from "./soundboard/sample/CustomSample";
-import { collectionStats } from "../modules/database/models";
+import * as models from "../modules/database/models";
 import { METRICS_PORT } from "../config";
 import { logErr } from "../util/util";
 import { lastItem } from "../util/array";
@@ -107,14 +107,14 @@ export class StatsCollectorManager extends EventEmitter {
 
         this.emit("collect", doc);
 
-        await collectionStats().insertOne(
+        await models.stats.collection.insertOne(
             doc,
         );
     }
 
     public getStats(timespan: number | Date): Promise<StatsSchema[]> {
         const now = new Date();
-        return collectionStats()
+        return models.stats.collection
             .find({
                 _id: {
                     $lte: now,

--- a/src/core/soundboard/methods/list.ts
+++ b/src/core/soundboard/methods/list.ts
@@ -3,10 +3,10 @@ import { BUTTON_TYPES } from "../../../const";
 import { createEmbed, EmbedType, replyEmbedEphemeral } from "../../../util/util";
 import InteractionRegistry from "../../InteractionRegistry";
 import { CustomSample, AvailableCustomSamplesResponse } from "../sample/CustomSample";
-import { PredefinedSample } from "../sample/PredefinedSample";
+import { StandardSample } from "../sample/StandardSample";
 
 interface AvailableSamplesResponse extends AvailableCustomSamplesResponse {
-    standard: PredefinedSample[];
+    standard: StandardSample[];
 }
 
 async function getAllAvailableSamples(guildId: Discord.Snowflake | null, userId: Discord.Snowflake): Promise<AvailableSamplesResponse> {
@@ -14,7 +14,7 @@ async function getAllAvailableSamples(guildId: Discord.Snowflake | null, userId:
         ? { user: await CustomSample.getUserSamples(userId), guild: await CustomSample.getGuildSamples(guildId) }
         : { user: await CustomSample.getUserSamples(userId), guild: [] };
 
-    const standard = await PredefinedSample.getSamples();
+    const standard = await StandardSample.getSamples();
 
     return {
         total: user.length + guild.length,
@@ -24,7 +24,7 @@ async function getAllAvailableSamples(guildId: Discord.Snowflake | null, userId:
     };
 }
 
-function generateSampleButtons(samples: CustomSample[] | PredefinedSample[]): Discord.MessageActionRow[] {
+function generateSampleButtons(samples: CustomSample[] | StandardSample[]): Discord.MessageActionRow[] {
     const rows: Discord.MessageActionRow[] = [];
     let i = 0;
 
@@ -96,7 +96,7 @@ async function scopeAll(interaction: Discord.CommandInteraction): Promise<void> 
 async function scopeStandard(interaction: Discord.CommandInteraction): Promise<void> {
     const client = interaction.client as Discord.Client<true>;
 
-    const standard = await PredefinedSample.getSamples();
+    const standard = await StandardSample.getSamples();
 
     const reply = (opts: Discord.InteractionReplyOptions) => {
         return interaction.replied ? interaction.channel?.send(opts) : interaction.reply(opts);

--- a/src/core/soundboard/methods/upload.ts
+++ b/src/core/soundboard/methods/upload.ts
@@ -12,7 +12,7 @@ import { downloadFile, isEnoughDiskSpace } from "../../../util/files";
 
 import SampleID from "../SampleID";
 import { CustomSample } from "../sample/CustomSample";
-import { PredefinedSample } from "../sample/PredefinedSample";
+import { StandardSample } from "../sample/StandardSample";
 import { EmbedType, isOwner, logErr, replyEmbed } from "../../../util/util";
 import GuildConfigManager from "../../GuildConfigManager";
 
@@ -108,7 +108,7 @@ async function _upload(interaction: Discord.CommandInteraction, name: string, sc
     switch (scope) {
         case "user": sample_count = await CustomSample.countUserSamples(userId); break;
         case "server": sample_count = await CustomSample.countGuildSamples(guildId!); break;
-        case "standard": sample_count = await PredefinedSample.countSamples(); break;
+        case "standard": sample_count = await StandardSample.countSamples(); break;
     }
 
     if (sample_count >= MAX_SAMPLES) {
@@ -169,7 +169,7 @@ async function _upload(interaction: Discord.CommandInteraction, name: string, sc
     switch (scope) {
         case "user": name_exists = !!await CustomSample.findSampleUser(userId, name); break;
         case "server": name_exists = !!await CustomSample.findSampleGuild(guildId!, name); break;
-        case "standard": name_exists = !!await PredefinedSample.findByName(name); break;
+        case "standard": name_exists = !!await StandardSample.findByName(name); break;
     }
     if (name_exists) {
         return await failed(UploadErrors.NameExists);
@@ -245,9 +245,9 @@ async function _upload(interaction: Discord.CommandInteraction, name: string, sc
 
         await CustomSample.ensureDir();
     } else {
-        sample_file = PredefinedSample.generateFilePath(name);
+        sample_file = StandardSample.generateFilePath(name);
 
-        await PredefinedSample.ensureDir();
+        await StandardSample.ensureDir();
     }
 
     await fs.move(temp_conversion_file, sample_file);
@@ -256,7 +256,7 @@ async function _upload(interaction: Discord.CommandInteraction, name: string, sc
 
     await status("Saving to database and finishing up...");
 
-    let sample: CustomSample | PredefinedSample;
+    let sample: CustomSample | StandardSample;
 
     if (scope !== "standard") {
         sample = await CustomSample.create({
@@ -272,7 +272,7 @@ async function _upload(interaction: Discord.CommandInteraction, name: string, sc
             modified_at: new Date(),
         });
     } else {
-        sample = await PredefinedSample.create({
+        sample = await StandardSample.create({
             name: name,
             orig_filename: attachment.name || undefined,
             plays: 0,

--- a/src/core/soundboard/sample/AbstractSample.ts
+++ b/src/core/soundboard/sample/AbstractSample.ts
@@ -4,7 +4,7 @@ import * as Voice from "@discordjs/voice";
 import Discord from "discord.js";
 
 import { DATA_BASE } from "../../../config";
-import { SoundboardPredefinedSampleSchema } from "../../../modules/database/schemas/SoundboardPredefinedSampleSchema";
+import { SoundboardStandardSampleSchema } from "../../../modules/database/schemas/SoundboardStandardSampleSchema";
 import { EmbedType } from "../../../util/util";
 
 const BASE = path.join(DATA_BASE, "soundboard");
@@ -18,7 +18,7 @@ export interface ToEmbedOptions {
     type?: EmbedType;
 }
 
-export abstract class AbstractSample implements SoundboardPredefinedSampleSchema {
+export abstract class AbstractSample implements SoundboardStandardSampleSchema {
     abstract readonly importable: boolean;
     abstract readonly deletable: boolean;
 
@@ -29,7 +29,7 @@ export abstract class AbstractSample implements SoundboardPredefinedSampleSchema
     modified_at: Date;
     last_played_at: Date | undefined;
 
-    constructor(doc: SoundboardPredefinedSampleSchema) {
+    constructor(doc: SoundboardStandardSampleSchema) {
         this.name = doc.name;
         this.plays = doc.plays;
         this.orig_filename = doc.orig_filename || undefined;

--- a/src/core/soundboard/sample/CustomSample.ts
+++ b/src/core/soundboard/sample/CustomSample.ts
@@ -149,7 +149,7 @@ export class CustomSample extends AbstractSample implements SoundboardCustomSamp
 
     // //////// STATIC DB MANAGEMENT METHODS ////////
 
-    static async count(): Promise<number> {
+    static count(): Promise<number> {
         return models.custom_sample.estimatedCount();
     }
 

--- a/src/core/soundboard/sample/StandardSample.ts
+++ b/src/core/soundboard/sample/StandardSample.ts
@@ -9,20 +9,17 @@ import { createEmbed } from "../../../util/util";
 import { BUTTON_TYPES } from "../../../const";
 import Logger from "../../../log";
 import database from "../../../modules/database";
-import { collectionPredefinedSample } from "../../../modules/database/models";
-import { SoundboardPredefinedSampleSchema } from "../../../modules/database/schemas/SoundboardPredefinedSampleSchema";
+import * as models from "../../../modules/database/models";
+import { SoundboardStandardSampleSchema } from "../../../modules/database/schemas/SoundboardStandardSampleSchema";
 import { AbstractSample, ToEmbedOptions } from "./AbstractSample";
-import Cache from "../../../modules/Cache";
 
-const log = Logger.child({ label: "SampleManager => PredefinedSample" });
-
-const cache = new Cache<string, PredefinedSample>({ maxSize: 1000 });
+const log = Logger.child({ label: "SampleManager => StandardSample" });
 
 database.onConnect(async () => {
-    await collectionPredefinedSample().createIndex({ name: 1 }, { unique: true });
+    await models.standard_sample.collection.createIndex({ name: 1 }, { unique: true });
 });
 
-export class PredefinedSample extends AbstractSample implements SoundboardPredefinedSampleSchema {
+export class StandardSample extends AbstractSample implements SoundboardStandardSampleSchema {
     readonly importable: boolean = false;
     readonly deletable = false;
 
@@ -33,7 +30,7 @@ export class PredefinedSample extends AbstractSample implements SoundboardPredef
     modified_at: Date;
     last_played_at: Date | undefined;
 
-    constructor(doc: SoundboardPredefinedSampleSchema) {
+    constructor(doc: SoundboardStandardSampleSchema) {
         super(doc);
 
         this.name = doc.name;
@@ -45,7 +42,7 @@ export class PredefinedSample extends AbstractSample implements SoundboardPredef
     }
 
     get file(): string {
-        return PredefinedSample.generateFilePath(this.name);
+        return StandardSample.generateFilePath(this.name);
     }
 
     async play(audio_player: Voice.AudioPlayer): Promise<Voice.AudioResource<AbstractSample>> {
@@ -55,7 +52,7 @@ export class PredefinedSample extends AbstractSample implements SoundboardPredef
 
         const now = new Date();
 
-        await collectionPredefinedSample().updateOne(
+        await models.standard_sample.updateOne(
             { name: this.name },
             { $inc: { plays: 1 }, $set: { last_played_at: now } },
         );
@@ -98,41 +95,36 @@ export class PredefinedSample extends AbstractSample implements SoundboardPredef
 
     // //////// STATIC DB MANAGEMENT METHODS ////////
 
-    static async findByName(name: string): Promise<PredefinedSample | undefined> {
-        const doc = await collectionPredefinedSample().findOne({ name });
+    static async findByName(name: string): Promise<StandardSample | undefined> {
+        const doc = await models.standard_sample.findOne({ name });
         if (!doc) return;
 
-        return new PredefinedSample(doc);
+        return new StandardSample(doc);
     }
 
     static async countSamples(): Promise<number> {
-        return await collectionPredefinedSample().countDocuments({});
+        return await models.standard_sample.count({});
     }
 
-    static async getSamples(): Promise<PredefinedSample[]> {
-        const docs = await collectionPredefinedSample()
-            .find({})
-            .toArray();
+    static async getSamples(): Promise<StandardSample[]> {
+        const docs = await models.standard_sample.findMany({});
 
-        const samples: PredefinedSample[] = [];
+        const samples: StandardSample[] = [];
 
         for (const doc of docs) {
-            const sample = new PredefinedSample(doc);
-
-            samples.push(sample);
-            cache.set(sample.name, sample);
+            samples.push(new StandardSample(doc));
         }
 
         return samples;
     }
 
-    static async import(sample: AbstractSample): Promise<PredefinedSample> {
-        const file = PredefinedSample.generateFilePath(sample.name);
+    static async import(sample: AbstractSample): Promise<StandardSample> {
+        const file = StandardSample.generateFilePath(sample.name);
 
         await fs.ensureDir(path.dirname(file));
         await fs.copyFile(sample.file, file);
 
-        const new_sample = await PredefinedSample.create({
+        const new_sample = await StandardSample.create({
             name: sample.name,
             plays: 0,
             orig_filename: sample.orig_filename,
@@ -143,23 +135,23 @@ export class PredefinedSample extends AbstractSample implements SoundboardPredef
         return new_sample;
     }
 
-    static async create(doc: SoundboardPredefinedSampleSchema): Promise<PredefinedSample> {
-        await collectionPredefinedSample().insertOne(doc);
+    static async create(doc: SoundboardStandardSampleSchema): Promise<StandardSample> {
+        const new_doc = await models.standard_sample.insertOne(doc);
 
-        return new PredefinedSample(doc);
+        return new StandardSample(new_doc);
     }
 
-    static async remove(sample: PredefinedSample): Promise<void> {
-        await collectionPredefinedSample().deleteOne({ name: sample.name });
+    static async remove(sample: StandardSample): Promise<void> {
+        await models.standard_sample.deleteOne({ name: sample.name });
         await fs.unlink(sample.file);
     }
 
     static async ensureDir(): Promise<void> {
-        await fs.ensureDir(PredefinedSample.BASE, 0o0777);
+        await fs.ensureDir(StandardSample.BASE, 0o0777);
     }
 
     static generateFilePath(name: string): string {
-        return path.join(PredefinedSample.BASE, name + PredefinedSample.EXT);
+        return path.join(StandardSample.BASE, name + StandardSample.EXT);
     }
 
     static BASE = path.join(AbstractSample.BASE, "standard");

--- a/src/modules/DatabaseCache.ts
+++ b/src/modules/DatabaseCache.ts
@@ -1,0 +1,183 @@
+import { Collection, Document, Filter, FindCursor, FindOneAndReplaceOptions, FindOneAndUpdateOptions, FindOptions, OnlyFieldsOfType, OptionalId, PullOperator, SetFields, UpdateFilter } from "mongodb";
+import { Except, RequireAtLeastOne } from "type-fest";
+import Cache, { CacheOptions } from "./Cache";
+import database from "./database";
+
+export type CacheCreateAsFunc<T, C> = (doc: T) => C;
+
+export interface DatabaseCacheOptions<KeyName> extends CacheOptions {
+    indexName: KeyName;
+}
+
+// could be ? Type | U : Type, but unsure about the mongodb implementation,
+// so just keep it ? U : Type, as it fits my usecases
+export type CacheFilterCondition<Type> =
+    Type extends ReadonlyArray<infer U> ? U : Type;
+
+export type CacheFilter<T> =
+    & {
+        [K in keyof T]?: CacheFilterCondition<T[K]>;
+    }
+    & Partial<{
+        $or: CacheFilter<T>[]
+    }>;
+
+export type CacheUpdateFilter<T> =
+    RequireAtLeastOne<{
+        $set: Partial<T> & Record<string, any>;
+        $inc: OnlyFieldsOfType<T, number | undefined>;
+        $addToSet: SetFields<T>;
+        $pull: PullOperator<T>;
+    }>;
+
+/**
+ * A MongoDB request cacher for the most important functions
+ */
+export default class DatabaseCache<
+    TSchema extends Document,
+    KeyName extends keyof TSchema = keyof TSchema,
+    KeyType = TSchema[KeyName],
+> {
+    public readonly cache: Cache<KeyType, TSchema>;
+    public readonly collection_name: string;
+    public readonly index_name: KeyName;
+
+    public get collection(): Collection<TSchema> {
+        return database.collection<TSchema>(this.collection_name);
+    }
+
+    constructor(collection_name: string, opts: DatabaseCacheOptions<KeyName>) {
+        this.cache = new Cache(opts);
+        this.collection_name = collection_name;
+        this.index_name = opts.indexName;
+    }
+
+    private _filter(item: TSchema, filter: CacheFilter<TSchema>): boolean {
+        const requirements: boolean[] = [];
+
+        const filter_keys = Object.keys(filter);
+        if (filter_keys.length > 0) {
+            requirements.push(
+                filter_keys.every(key => {
+                    return Array.isArray(item[key])
+                        ? item[key].includes(filter[key])
+                        : item[key] === filter[key];
+                }),
+            );
+        } else {
+            requirements.push(true);
+        }
+
+        if (filter.$or) {
+            requirements.push(
+                filter.$or.some(sub_filter => this._filter(item, sub_filter)),
+            );
+        }
+
+        return requirements.every(a => a);
+    }
+
+    private _findOne(filter: CacheFilter<TSchema>): TSchema | undefined {
+        if (typeof filter[this.index_name] !== "undefined") {
+            const return_val = this.cache.get(filter[this.index_name] as KeyType);
+            if (return_val) return return_val;
+        }
+
+        return this.cache.find(item => {
+            return this._filter(item, filter);
+        });
+    }
+
+    // publics
+
+    async findOne(filter: CacheFilter<TSchema>): Promise<TSchema | undefined> {
+        let doc: TSchema | undefined;
+
+        doc = this._findOne(filter);
+        if (doc) return doc;
+
+        doc = await this.collection.findOne(filter);
+        if (!doc) return;
+
+        this.cache.set(doc[this.index_name], doc);
+
+        return doc;
+    }
+
+    async findMany(filter: Filter<TSchema>, cursor_func?: (cursor: FindCursor<TSchema>) => void, options?: FindOptions<TSchema>): Promise<TSchema[]> {
+        const cursor = this.collection.find(filter, options);
+        cursor_func && cursor_func(cursor);
+        const docs = await cursor.toArray();
+
+        for (const doc of docs) {
+            this.cache.set(doc[this.index_name], doc);
+        }
+
+        return docs;
+    }
+
+    async insertOne(doc: TSchema): Promise<TSchema> {
+        await this.collection.insertOne(doc as OptionalId<TSchema>);
+
+        this.cache.set(doc[this.index_name], doc);
+
+        return doc;
+    }
+
+    // async insertMany();
+
+    async updateOne(filter: CacheFilter<TSchema>, update: UpdateFilter<TSchema>, opts?: Except<FindOneAndUpdateOptions, "returnDocument">): Promise<TSchema | undefined> {
+        const result = await this.collection.findOneAndUpdate(
+            filter,
+            update,
+            { ...opts, returnDocument: "after" },
+        );
+
+        if (result.value) {
+            this.cache.set(result.value[this.index_name], result.value);
+            return result.value;
+        }
+
+        // if for a reason it didn't return a value, which
+        // should mostly be because this document doesn't
+        // exist in the collection, but we can't be sure,
+        // then delete it from cache, so there aren't any confusions
+        const doc = this._findOne(filter);
+        if (doc) this.cache.delete(doc[this.index_name]);
+    }
+
+    async replaceOne(filter: CacheFilter<TSchema>, replacement: TSchema, opts: FindOneAndReplaceOptions = {}): Promise<TSchema | undefined> {
+        const result = await this.collection.findOneAndReplace(filter, replacement, { ...opts, returnDocument: "after" });
+
+        if (result.value) {
+            this.cache.set(result.value[this.index_name], result.value);
+            return result.value;
+        }
+
+        // if for a reason it didn't return a value, which
+        // should mostly be because this document doesn't
+        // exist in the collection, but we can't be sure,
+        // then delete it from cache, so there aren't any confusions
+        const doc = this._findOne(filter);
+        if (doc) this.cache.delete(doc[this.index_name]);
+    }
+
+    // async updateMany();
+
+    async deleteOne(filter: CacheFilter<TSchema>): Promise<void> {
+        const doc = this._findOne(filter);
+        if (doc) this.cache.delete(doc[this.index_name]);
+
+        await this.collection.deleteOne(filter);
+    }
+
+    // async deleteMany();
+
+    count(filter: Filter<TSchema>): Promise<number> {
+        return this.collection.countDocuments(filter);
+    }
+
+    estimatedCount(): Promise<number> {
+        return this.collection.estimatedDocumentCount();
+    }
+}

--- a/src/modules/DatabaseCache.ts
+++ b/src/modules/DatabaseCache.ts
@@ -1,9 +1,7 @@
-import { Collection, Document, Filter, FindCursor, FindOneAndReplaceOptions, FindOneAndUpdateOptions, FindOptions, OnlyFieldsOfType, OptionalId, PullOperator, SetFields, UpdateFilter } from "mongodb";
-import { Except, RequireAtLeastOne } from "type-fest";
+import { Collection, Document, Filter, FindCursor, FindOneAndReplaceOptions, FindOneAndUpdateOptions, FindOptions, OptionalId, UpdateFilter } from "mongodb";
+import { Except } from "type-fest";
 import Cache, { CacheOptions } from "./Cache";
 import database from "./database";
-
-export type CacheCreateAsFunc<T, C> = (doc: T) => C;
 
 export interface DatabaseCacheOptions<KeyName> extends CacheOptions {
     indexName: KeyName;
@@ -20,14 +18,6 @@ export type CacheFilter<T> =
     }
     & Partial<{
         $or: CacheFilter<T>[]
-    }>;
-
-export type CacheUpdateFilter<T> =
-    RequireAtLeastOne<{
-        $set: Partial<T> & Record<string, any>;
-        $inc: OnlyFieldsOfType<T, number | undefined>;
-        $addToSet: SetFields<T>;
-        $pull: PullOperator<T>;
     }>;
 
 /**

--- a/src/modules/database/collections.ts
+++ b/src/modules/database/collections.ts
@@ -1,7 +1,7 @@
 export enum DbCollection {
     BlacklistUser = "blacklist_user",
     CustomSample = "soundboard_custom_sample",
-    PredefinedSample = "soundboard_pre_sample",
+    StandardSample = "soundboard_pre_sample",
     Config = "guild_config",
     Stats = "app_stats"
 }

--- a/src/modules/database/models.ts
+++ b/src/modules/database/models.ts
@@ -1,29 +1,18 @@
-import { Collection } from "mongodb";
-import { get } from ".";
+import DatabaseCache from "../DatabaseCache";
 import { DbCollection } from "./collections";
 
 import { BlacklistUserSchema } from "./schemas/BlacklistUserSchema";
 import { ConfigSchema } from "./schemas/ConfigSchema";
 import { SoundboardCustomSampleSchema } from "./schemas/SoundboardCustomSampleSchema";
-import { SoundboardPredefinedSampleSchema } from "./schemas/SoundboardPredefinedSampleSchema";
+import { SoundboardStandardSampleSchema } from "./schemas/SoundboardStandardSampleSchema";
 import { StatsSchema } from "./schemas/StatsSchema";
 
-export function collectionBlacklistUser(): Collection<BlacklistUserSchema> {
-    return get().collection<BlacklistUserSchema>(DbCollection.BlacklistUser);
-}
+export const blacklist_user = new DatabaseCache<BlacklistUserSchema>(DbCollection.BlacklistUser, { indexName: "userId" });
 
-export function collectionCustomSample(): Collection<SoundboardCustomSampleSchema> {
-    return get().collection<SoundboardCustomSampleSchema>(DbCollection.CustomSample);
-}
+export const custom_sample = new DatabaseCache<SoundboardCustomSampleSchema>(DbCollection.CustomSample, { indexName: "id", maxSize: 1000 });
 
-export function collectionPredefinedSample(): Collection<SoundboardPredefinedSampleSchema> {
-    return get().collection<SoundboardPredefinedSampleSchema>(DbCollection.PredefinedSample);
-}
+export const standard_sample = new DatabaseCache<SoundboardStandardSampleSchema>(DbCollection.StandardSample, { indexName: "name" });
 
-export function collectionConfig(): Collection<ConfigSchema> {
-    return get().collection<ConfigSchema>(DbCollection.Config);
-}
+export const config = new DatabaseCache<ConfigSchema>(DbCollection.Config, { indexName: "guildId" });
 
-export function collectionStats(): Collection<StatsSchema> {
-    return get().collection<StatsSchema>(DbCollection.Stats);
-}
+export const stats = new DatabaseCache<StatsSchema>(DbCollection.Stats, { indexName: "_id", ttl: 1, maxSize: 1 }); // basically disabling cache

--- a/src/modules/database/schemas/SoundboardCustomSampleSchema.ts
+++ b/src/modules/database/schemas/SoundboardCustomSampleSchema.ts
@@ -1,8 +1,8 @@
-import { SoundboardPredefinedSampleSchema } from "./SoundboardPredefinedSampleSchema";
+import { SoundboardStandardSampleSchema } from "./SoundboardStandardSampleSchema";
 
 export type SoundboardCustomSampleScope = "user" | "server";
 
-export interface SoundboardCustomSampleSchema extends SoundboardPredefinedSampleSchema {
+export interface SoundboardCustomSampleSchema extends SoundboardStandardSampleSchema {
     id: string;
     creatorId: string;
     scope: SoundboardCustomSampleScope;

--- a/src/modules/database/schemas/SoundboardStandardSampleSchema.ts
+++ b/src/modules/database/schemas/SoundboardStandardSampleSchema.ts
@@ -1,4 +1,4 @@
-export interface SoundboardPredefinedSampleSchema {
+export interface SoundboardStandardSampleSchema {
     name: string;
     orig_filename?: string;
     plays: number;


### PR DESCRIPTION
This PR adds a database caching class to improve current half-baked caching.

**Status**
- [X] Code changes have been tested and are working, or there are no code changes.
- [X] I ran `npm run lint` to ensure there to be no errors, or there are no code changes.

**Semantic versioning classification:**  
- [ ] This PR changes the bot's interface (commands added)
  - [ ] This PR includes breaking changes (commands moved or removed, or execution of commands changed)
- [ ] This PR **only** includes non-code changes, like changes to README, etc.
